### PR TITLE
Implemented uniform location caching

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -419,7 +419,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_ShaderEnd(const CCommandBuffer::SComm
 GLint CCommandProcessorFragment_OpenGL::CShader::getUniformLocation(const GLcharARB *pName)
 {
 	GLint& rCachePos = m_aUniformLocationCache[pName].value;
-	if(rCachePos >= 0)
+	if(rCachePos > -2)
 		return rCachePos;
 
 	return (rCachePos = glGetUniformLocationARB(m_Program, pName));

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -15,8 +15,6 @@
 #include "shaders.h"
 #include "backend_sdl.h"
 
-constexpr const char * const CCommandProcessorFragment_OpenGL::CUniformLocationCache::ms_apUniformNames[CCommandProcessorFragment_OpenGL::CUniformLocationCache::NUM_UNIFORMS];
-
 
 // ------------ CGraphicsBackend_Threaded
 
@@ -393,21 +391,20 @@ void CCommandProcessorFragment_OpenGL::Cmd_LoadShaders(const CCommandBuffer::SCo
 	m_aShader[SHADER_INVISIBILITY] = LoadShader("data/shaders/basic.vert", "data/shaders/invisibility.frag");
 	m_aShader[SHADER_RAGE] = LoadShader("data/shaders/basic.vert", "data/shaders/rage.frag");
 	m_aShader[SHADER_FUEL] = LoadShader("data/shaders/basic.vert", "data/shaders/fuel.frag");
-	for(int i = 0; i < NUM_SHADERS; i++)
-		m_aShaderLocationCache[i] = CUniformLocationCache();
 }
 
 
 
 void CCommandProcessorFragment_OpenGL::Cmd_ShaderBegin(const CCommandBuffer::SCommand_ShaderBegin *pCommand)
 {
-	glUseProgramObjectARB(m_aShader[pCommand->m_Shader]);
+	CShader *pShader = &(m_aShader[pCommand->m_Shader]);
+	glUseProgramObjectARB(pShader->Handle());
 	
-	GLint location = getUniformLocation(pCommand->m_Shader, CUniformLocationCache::UNIFORM_RND);
+	GLint location = pShader->getUniformLocation("rnd");
 	if (location >= 0)
 		glUniform1fARB(location, GLfloat(frandom()));
-	
-	location = getUniformLocation(pCommand->m_Shader, CUniformLocationCache::UNIFORM_INTENSITY);
+
+	location = pShader->getUniformLocation("intensity");
 	if (location >= 0)
 		glUniform1fARB(location, GLfloat(pCommand->m_Intensity));
 }
@@ -419,13 +416,13 @@ void CCommandProcessorFragment_OpenGL::Cmd_ShaderEnd(const CCommandBuffer::SComm
 }
 
 
-GLint CCommandProcessorFragment_OpenGL::getUniformLocation(int Shader, int Uniform)
+GLint CCommandProcessorFragment_OpenGL::CShader::getUniformLocation(const GLcharARB *pName)
 {
-	GLint& rCachePos = m_aShaderLocationCache[Shader].m_aLocations[Uniform];
+	GLint& rCachePos = m_aUniformLocationCache[pName].value;
 	if(rCachePos >= 0)
 		return rCachePos;
 
-	return (rCachePos = glGetUniformLocationARB(m_aShader[Shader], CUniformLocationCache::ms_apUniformNames[Uniform]));
+	return (rCachePos = glGetUniformLocationARB(m_Program, pName));
 }
 
 

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <map>
+
 #include "graphics_threaded.h"
 #include <SDL.h>
 #include <SDL_opengl.h>
@@ -99,30 +101,26 @@ class CCommandProcessorFragment_OpenGL
 	
 	GLuint textureBuffer[NUM_RENDERBUFFERS];
 	GLuint renderedTexture[NUM_RENDERBUFFERS];
-	GLuint m_aShader[NUM_SHADERS];
 
-	struct CUniformLocationCache // TODO: new generalized uniforms must be added here.
+	class CShader
 	{
-		enum
+		struct CUniformLocation
 		{
-			UNIFORM_RND,
-			UNIFORM_INTENSITY,
-			NUM_UNIFORMS
+			GLint value;
+			CUniformLocation() { value = -1; } // need this to initialize new keys in our map correctly
 		};
 
-		static constexpr const char * const ms_apUniformNames[NUM_UNIFORMS] = {
-				"rnd",
-				"intensity"
-		};
+		GLuint m_Program;
+		std::map<const GLcharARB*, CUniformLocation> m_aUniformLocationCache;
 
-		CUniformLocationCache() { for(int i = 0; i < NUM_UNIFORMS; i++) m_aLocations[i] = -1; }
+	public:
+		GLuint Handle() const { return m_Program; }
+		GLint getUniformLocation(const char *pName);
 
-		GLint m_aLocations[NUM_UNIFORMS];
+		GLuint operator=(GLuint Program) { return (m_Program = Program); } // to easily assign a linked shader program
 	};
+	CShader m_aShader[NUM_SHADERS];
 
-	CUniformLocationCache m_aShaderLocationCache[NUM_SHADERS];
-	GLint getUniformLocation(int Shader, int Uniform);
-	
 public:
 	enum
 	{

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -100,6 +100,28 @@ class CCommandProcessorFragment_OpenGL
 	GLuint textureBuffer[NUM_RENDERBUFFERS];
 	GLuint renderedTexture[NUM_RENDERBUFFERS];
 	GLuint m_aShader[NUM_SHADERS];
+
+	struct CUniformLocationCache // TODO: new generalized uniforms must be added here.
+	{
+		enum
+		{
+			UNIFORM_RND,
+			UNIFORM_INTENSITY,
+			NUM_UNIFORMS
+		};
+
+		static constexpr const char * const ms_apUniformNames[NUM_UNIFORMS] = {
+				"rnd",
+				"intensity"
+		};
+
+		CUniformLocationCache() { for(int i = 0; i < NUM_UNIFORMS; i++) m_aLocations[i] = -1; }
+
+		GLint m_aLocations[NUM_UNIFORMS];
+	};
+
+	CUniformLocationCache m_aShaderLocationCache[NUM_SHADERS];
+	GLint getUniformLocation(int Shader, int Uniform);
 	
 public:
 	enum

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -107,7 +107,7 @@ class CCommandProcessorFragment_OpenGL
 		struct CUniformLocation
 		{
 			GLint value;
-			CUniformLocation() { value = -1; } // need this to initialize new keys in our map correctly
+			CUniformLocation() { value = -2; } // need this to initialize new keys in our map correctly
 		};
 
 		GLuint m_Program;


### PR DESCRIPTION
As a call to `glGetUniformLocation` can be quite slow and it returns every time the same, caching the result will speed the whole thing up eventually.
Even if a result can't be seen in the FPS for example, I guess it's considered good practice anyway...


For now I kept the structure of it flat and very static, since you had also hardcoded the uniform names before. But it can easily be turned into something dynamic later if needed (e.g caching the location of any arbitrary uniform).


If you are not ok with the implementation or code, please tell me and I'll change it to your likes :)
Or if you just don't care about stuff like this then just go ahead and close it :P