### PR TITLE
Use abort() instead of nullptr dereference for dbg_break()

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -80,7 +80,7 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg)
 
 void dbg_break()
 {
-	*((volatile unsigned*)0) = 0x0;
+	abort();
 }
 
 void dbg_msg(const char *sys, const char *fmt, ...)


### PR DESCRIPTION
Just a tiny thing that always annoyed me.

This little change breaks the program with a proper `SIGABRT` (which is expected in such a case) instead of `SIGSEGV`.

There's also a use of this for the average Joe who doesn't use a debugger... it prints "Aborted" instead of "Segmentation fault" into their console, letting them know that something expectedly wrong happened :)