### PR TITLE
Don't start the game when missing skeletons to avoid confusion

### DIFF
--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -137,7 +137,7 @@ public:
 public:
 
 	CAnimSkeletonInfo() {}
-	~CAnimSkeletonInfo();
+	virtual ~CAnimSkeletonInfo();
 
 	void UpdateBones(float Time = 0.0f, CSpineAnimation *pAnimation = 0x0, class CSkeletonAnimation *pAnimData = 0x0, int WeaponAngle = 0);
 	void UpdateBones(float Time1, float Time2, CSpineAnimation *pAnimation1, CSpineAnimation *pAnimation2, float Mix);
@@ -201,14 +201,14 @@ public:
 	void DrawRoundRectExt(float x, float y, float w, float h, float r, int Corners);
 
 	void DrawUIRect(const CUIRect *pRect, vec4 Color, int Corners, float Rounding);
-	
+
 	// larger rendering methods
 	void RenderTilemapGenerateSkip(class CLayers *pLayers);
 
 	// object render methods (gc_render_obj.cpp)
 	//void RenderTee(class CAnimState *pAnim, CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos);
-	
-	
+
+
 	// for selection menu
 	void RenderTopper(CTeeRenderInfo *pInfo, vec2 Pos);
 	void RenderEye(CTeeRenderInfo *pInfo, vec2 Pos);
@@ -216,16 +216,16 @@ public:
 
 	void RenderShield(vec2 Pos, vec2 Size, float State);
 	void RenderHeal(vec2 Pos, vec2 Size, float State);
-	
+
 	// render player with custom info (teesplatter, bounciness etc...)
 	void RenderPlayer(class CPlayerInfo *PlayerInfo, CTeeRenderInfo *pInfo, int WeaponNum, int Emote, vec2 Dir, vec2 Pos);
-	
-	
+
+
 	void RenderStaticPlayer(CTeeRenderInfo *pInfo, vec2 Pos);
 	void RenderPortrait(CTeeRenderInfo *pInfo, vec2 Position, int EyeType);
 
 	void RenderMonster(vec2 Pos, float Time, int Dir, int Status);
-	
+
 	// skeleton render methods
 	void RenderSkeleton(vec2 Position, CTeeRenderInfo *pInfo, class CSkeletonAnimation *AnimData, float Rotation, CAnimSkeletonInfo *pSkeleton, CTextureAtlas *pAtlas, class CPlayerInfo *PlayerInfo = NULL);
 	void RenderBuilding(vec2 Position, CAnimSkeletonInfo *pSkeleton, CTextureAtlas *pAtlas, int Team, int WeaponAngle = 0);
@@ -233,7 +233,7 @@ public:
 	template<typename TKeyframe>
 	static void RenderEvalSkeletonAnim(TKeyframe *pKeyFrame, int NumKeyframes, float Time, typename TKeyframe::KeyframeReturnType *pResult);
 
-	
+
 	// map render methods (gc_render_map.cpp)
 	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, float Time, float *pResult);
 	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
@@ -245,7 +245,7 @@ public:
 
 	vec3 GetColorV3(int v);
 
-	
+
 	void RenderFullScreenLayer();
 };
 

--- a/src/game/client/skelebank.cpp
+++ b/src/game/client/skelebank.cpp
@@ -11,26 +11,26 @@ CSkelebank::CSkelebank(CRenderTools *pRenderTools)
 void CSkelebank::Init(IStorage *pStorage)
 {
 	m_pStorage = pStorage;
-	
+
 	AddSkeleton("data/anim/body1.json", IStorage::STORAGETYPE_CLIENT);
 	AddAtlas("data/anim/body1.atlas", IStorage::STORAGETYPE_CLIENT);
-	
+
 	AddSkeleton("data/anim/body2.json", IStorage::STORAGETYPE_CLIENT);
 	AddAtlas("data/anim/body2.atlas", IStorage::STORAGETYPE_CLIENT);
-	
+
 	AddSkeleton("data/anim/body3.json", IStorage::STORAGETYPE_CLIENT);
 	AddAtlas("data/anim/body3.atlas", IStorage::STORAGETYPE_CLIENT);
-	
+
 	AddSkeleton("data/anim/turret.json", IStorage::STORAGETYPE_CLIENT);
 	AddAtlas("data/anim/turret.atlas", IStorage::STORAGETYPE_CLIENT);
-	
+
 	AddSkeleton("data/anim/monster1.json", IStorage::STORAGETYPE_CLIENT);
 	AddAtlas("data/anim/monster1.atlas", IStorage::STORAGETYPE_CLIENT);
 }
 
 CSkelebank::~CSkelebank()
 {
-	
+
 }
 
 void CSkelebank::AddSkeleton(const char *pFilename, int StorageType)
@@ -43,24 +43,24 @@ void CSkelebank::AddSkeleton(const char *pFilename, int StorageType)
 		if(!str_comp(m_lSkeletons[i]->m_aName, aBuf))
 			return;
 	}
-	
+
 	// load spine data
 	array<CSpineBone> lBones;
 	array<CSpineSlot> lSlots;
 	SkinMap mSkins;
 	std::map<string, CSpineAnimation> mAnimations;
-	
+
 	if(!m_SpineReader.LoadFromFile(Storage(), pFilename, StorageType, &lBones, &lSlots, &mSkins, &mAnimations))
 	{
-		dbg_msg("spinebank", "Unable to load spine skeleton: %s", pFilename);
-		return;
+		dbg_msg("spinebank", "FATAL: Unable to load spine skeleton: '%s', game will exit.", pFilename);
+		dbg_break(); // game will crash without having the skeletons, so just exit it right away to avoid confusion
 	}
-	
+
 	CSkelebankSkeleton *pSkeletonInfo = new CSkelebankSkeleton();
 	RenderTools()->LoadSkeletonFromSpine(pSkeletonInfo, lBones, lSlots, mSkins, mAnimations);
 	pSkeletonInfo->m_External = 1; // external by default;
 	str_copy(pSkeletonInfo->m_aName, aBuf, sizeof(pSkeletonInfo->m_aName));
-	
+
 	// load file content, uhm double-work actually
 	IOHANDLE File = Storage()->OpenFile(pFilename, IOFLAG_READ, StorageType);
 	if(!File)
@@ -72,7 +72,7 @@ void CSkelebank::AddSkeleton(const char *pFilename, int StorageType)
 	io_read(File, pSkeletonInfo->m_pJsonData, DataSize);
 	pSkeletonInfo->m_pJsonData[DataSize] = '\0';
 	io_close(File);
-	
+
 	//
 	m_lSkeletons.add(pSkeletonInfo);
 }


### PR DESCRIPTION
It might be misleading for error finding if the game crashes when you join a server or try to click on the 'Customize' tab. Instead, just don't start it and have an error message right at the bottom of the console.