### PR TITLE
Fixed environmental sounds crackling because of implicit conversion t…

### DIFF
--- a/src/game/client/components/buildings.cpp
+++ b/src/game/client/components/buildings.cpp
@@ -132,7 +132,7 @@ void CBuildings::RenderSpeaker(const struct CNetObj_Building *pCurrent)
 	
 	if (currentTime > CustomStuff()->m_aBGSound[i])
 	{
-		CustomStuff()->m_aBGSound[i] = currentTime+time_freq()*3.7f;
+		CustomStuff()->m_aBGSound[i] = currentTime+int(time_freq()*3.7f);
 		m_pClient->m_pSounds->PlayAt(CSounds::CHN_WORLD, SOUND_BG1+i%13, 1.0f, p);
 	}
 	


### PR DESCRIPTION
…o float, which cannot contain int64 value range

This happens on Linux and on Android, where time_get() returns the amount of microseconds since Jan 1 1970, not since PC last reboot, as on Windows.