### PR TITLE
Fixed crash when explosions were killing droids

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -729,7 +729,7 @@ void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon)
 	}
 	
 	CDroid *apDEnts[MAX_CLIENTS];
-	int DNum = m_World.FindEntities(Pos, Radius, (CEntity**)apEnts,
+	int DNum = m_World.FindEntities(Pos, Radius, (CEntity**)apDEnts,
 									MAX_CLIENTS, CGameWorld::ENTTYPE_DROID);
 	
 	for (int i = 0; i < DNum; ++i)


### PR DESCRIPTION
ROT IN HELL, COPY PASTA! 

:smirk: 

p.s.: it struck me that FindEntities would return entities that are already invalid. and since this all happens in a single thread, if findentities returns only valid entities, they remain valid until the damage is dealt (everything working as intended). It just cant work if you're filling the wrong buffer :bug: 

so in the end, it was a copy pasta and one unchanged typo