### PR TITLE
Fix client & server build

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -21,7 +21,7 @@ function Script(name)
 	if family == "windows" then
 		return str_replace(name, "/", "\\")
 	end
-	return "python " .. name
+	return "python3 " .. name
 end
 
 function CHash(output, ...)

--- a/other/freetype/freetype.lua
+++ b/other/freetype/freetype.lua
@@ -5,12 +5,16 @@ FreeType = {
 		local check = function(option, settings)
 			option.value = false
 			option.use_ftconfig = false
+			option.use_pkgconfig = false
 			option.use_winlib = 0
 			option.lib_path = nil
 			
 			if ExecuteSilent("freetype-config") > 0 and ExecuteSilent("freetype-config --cflags") == 0 then
 				option.value = true
 				option.use_ftconfig = true
+			elseif ExecuteSilent("pkg-config") > 0 and ExecuteSilent("pkg-config freetype2") == 0 then
+				option.value = true
+				option.use_pkgconfig = true
 			end
 				
 			if platform == "win32" then
@@ -29,6 +33,9 @@ FreeType = {
 			if option.use_ftconfig == true then
 				settings.cc.flags:Add("`freetype-config --cflags`")
 				settings.link.flags:Add("`freetype-config --libs`")
+			elseif option.use_pkgconfig == true then
+				settings.cc.flags:Add("`pkg-config freetype2 --cflags`")
+				settings.link.flags:Add("`pkg-config freetype2 --libs`")
 				
 			elseif option.use_winlib > 0 then
 				if option.use_winlib == 32 then
@@ -43,12 +50,14 @@ FreeType = {
 		local save = function(option, output)
 			output:option(option, "value")
 			output:option(option, "use_ftconfig")
+			output:option(option, "use_pkgconfig")
 			output:option(option, "use_winlib")
 		end
 		
 		local display = function(option)
 			if option.value == true then
 				if option.use_ftconfig == true then return "using freetype-config" end
+				if option.use_pkgconfig == true then return "using pkg-config" end
 				if option.use_winlib == 32 then return "using supplied win32 libraries" end
 				if option.use_winlib == 64 then return "using supplied win64 libraries" end
 				return "using unknown method"

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -606,3 +606,6 @@ void CNetBan::ConBansSave(IConsole::IResult *pResult, void *pUser)
 	str_format(aBuf, sizeof(aBuf), "saved banlist to '%s'", pResult->GetString(0));
 	pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
 }
+
+template void CNetBan::MakeBanInfo<CNetRange>(const CBan<CNetRange> *pBan, char *pBuf, unsigned BufferSize, int Type) const;
+template void CNetBan::MakeBanInfo<NETADDR>(const CBan<NETADDR> *pBan, char *pBuf, unsigned BufferSize, int Type) const;


### PR DESCRIPTION
Fix client build
`
other/freetype/include/freetype/config/ftconfig.h:42,
                 from
 other/freetype/include/freetype/freetype.h:33,
                 from src/engine/client/text.cpp:14:
other/freetype/include/freetype/config/ftoption.h:257:32: error: expected constructor, destructor, or type conversion before « ( » token
  257 | #define FT_EXPORT(x) __declspec(dllexport) x
      |                                ^
`

Fix server build
![image](https://github.com/Siile/Ninslash/assets/74450074/20fc1314-48b6-4775-9436-8c3f64e0ccea)
