### PR TITLE
Changed the format of the console log and make it colorful

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -88,9 +88,17 @@ void dbg_msg(const char *sys, const char *fmt, ...)
 	va_list args;
 	char str[1024*4];
 	char *msg;
+	char atime[64];
 	int i, len;
+	time_t time_data;
+	struct tm *time_info;
 
-	str_format(str, sizeof(str), "[%08x][%s]: ", (int)time(0), sys);
+	time(&time_data);
+	time_info = localtime(&time_data);
+	strftime(atime, sizeof(atime), "%Y-%m-%d %H-%M-%S", time_info);
+
+	str_format(str, sizeof(str), "%s | [%s]: ", atime, sys);
+
 	len = strlen(str);
 	msg = (char *)str + len;
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -97,7 +97,7 @@ void dbg_msg(const char *sys, const char *fmt, ...)
 	time_info = localtime(&time_data);
 	strftime(atime, sizeof(atime), "%Y-%m-%d %H-%M-%S", time_info);
 
-	str_format(str, sizeof(str), "%s | [%s]: ", atime, sys);
+	str_format(str, sizeof(str), COLOR_RESET COLOR_BLACK_BRIGHT "%s" COLOR_WHITE_BRIGHT " | " COLOR_CYAN "[%s]: " COLOR_RESET, atime, sys);
 
 	len = strlen(str);
 	msg = (char *)str + len;

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -97,7 +97,7 @@ void dbg_msg(const char *sys, const char *fmt, ...)
 	time_info = localtime(&time_data);
 	strftime(atime, sizeof(atime), "%Y-%m-%d %H-%M-%S", time_info);
 
-	str_format(str, sizeof(str), COLOR_RESET COLOR_BLACK_BRIGHT "%s" COLOR_WHITE_BRIGHT " | " COLOR_CYAN "[%s]: " COLOR_RESET, atime, sys);
+	str_format(str, sizeof(str), "%s | [%s]: ", atime, sys);
 
 	len = strlen(str);
 	msg = (char *)str + len;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1306,6 +1306,49 @@ int str_utf8_encode(char *ptr, int chr);
 */
 int str_utf8_check(const char *str);
 
+// Reset color
+#define COLOR_RESET "\033[0m"
+
+// Basic colors
+#define COLOR_BLACK "\033[30m"
+#define COLOR_RED "\033[31m"
+#define COLOR_GREEN "\033[32m"
+#define COLOR_YELLOW "\033[33m"
+#define COLOR_BLUE "\033[34m"
+#define COLOR_MAGENTA "\033[35m"
+#define COLOR_CYAN "\033[36m"
+#define COLOR_WHITE "\033[37m"
+
+// Bright colors
+#define COLOR_BLACK_BRIGHT "\033[90m"
+#define COLOR_RED_BRIGHT "\033[91m"
+#define COLOR_GREEN_BRIGHT "\033[92m"
+#define COLOR_YELLOW_BRIGHT "\033[93m"
+#define COLOR_BLUE_BRIGHT "\033[94m"
+#define COLOR_MAGENTA_BRIGHT "\033[95m"
+#define COLOR_CYAN_BRIGHT "\033[96m"
+#define COLOR_WHITE_BRIGHT "\033[97m"
+
+// Background colors
+#define COLOR_BLACK_BG "\033[40m"
+#define COLOR_RED_BG "\033[41m"
+#define COLOR_GREEN_BG "\033[42m"
+#define COLOR_YELLOW_BG "\033[43m"
+#define COLOR_BLUE_BG "\033[44m"
+#define COLOR_MAGENTA_BG "\033[45m"
+#define COLOR_CYAN_BG "\033[46m"
+#define COLOR_WHITE_BG "\033[47m"
+
+// Bright background colors
+#define COLOR_BLACK_BG_BRIGHT "\033[100m"
+#define COLOR_RED_BG_BRIGHT "\033[101m"
+#define COLOR_GREEN_BG_BRIGHT "\033[102m"
+#define COLOR_YELLOW_BG_BRIGHT "\033[103m"
+#define COLOR_BLUE_BG_BRIGHT "\033[104m"
+#define COLOR_MAGENTA_BG_BRIGHT "\033[105m"
+#define COLOR_CYAN_BG_BRIGHT "\033[106m"
+#define COLOR_WHITE_BG_BRIGHT "\033[107m"
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1306,49 +1306,6 @@ int str_utf8_encode(char *ptr, int chr);
 */
 int str_utf8_check(const char *str);
 
-// Reset color
-#define COLOR_RESET "\033[0m"
-
-// Basic colors
-#define COLOR_BLACK "\033[30m"
-#define COLOR_RED "\033[31m"
-#define COLOR_GREEN "\033[32m"
-#define COLOR_YELLOW "\033[33m"
-#define COLOR_BLUE "\033[34m"
-#define COLOR_MAGENTA "\033[35m"
-#define COLOR_CYAN "\033[36m"
-#define COLOR_WHITE "\033[37m"
-
-// Bright colors
-#define COLOR_BLACK_BRIGHT "\033[90m"
-#define COLOR_RED_BRIGHT "\033[91m"
-#define COLOR_GREEN_BRIGHT "\033[92m"
-#define COLOR_YELLOW_BRIGHT "\033[93m"
-#define COLOR_BLUE_BRIGHT "\033[94m"
-#define COLOR_MAGENTA_BRIGHT "\033[95m"
-#define COLOR_CYAN_BRIGHT "\033[96m"
-#define COLOR_WHITE_BRIGHT "\033[97m"
-
-// Background colors
-#define COLOR_BLACK_BG "\033[40m"
-#define COLOR_RED_BG "\033[41m"
-#define COLOR_GREEN_BG "\033[42m"
-#define COLOR_YELLOW_BG "\033[43m"
-#define COLOR_BLUE_BG "\033[44m"
-#define COLOR_MAGENTA_BG "\033[45m"
-#define COLOR_CYAN_BG "\033[46m"
-#define COLOR_WHITE_BG "\033[47m"
-
-// Bright background colors
-#define COLOR_BLACK_BG_BRIGHT "\033[100m"
-#define COLOR_RED_BG_BRIGHT "\033[101m"
-#define COLOR_GREEN_BG_BRIGHT "\033[102m"
-#define COLOR_YELLOW_BG_BRIGHT "\033[103m"
-#define COLOR_BLUE_BG_BRIGHT "\033[104m"
-#define COLOR_MAGENTA_BG_BRIGHT "\033[105m"
-#define COLOR_CYAN_BG_BRIGHT "\033[106m"
-#define COLOR_WHITE_BG_BRIGHT "\033[107m"
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
It looks like 👇
![image](https://github.com/user-attachments/assets/b06bc8a1-73d5-4ca5-898f-d2c3321d873b)
Tested on Windows 11 and Ubuntu 22.04 systems